### PR TITLE
Specified the "main" file for this dependecy

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -1,7 +1,7 @@
 {
   "name": "angular-save-html-to-pdf",
   "description": "Save HTML in pdf format by angularjs . Directives which are using libraries to convert html to html5canvas and save html5canvas as pdf .",
-  "main": "index.js",
+  "main": "dist/saveHtmlToPdf.js",
   "authors": [
     "hearsid"
   ],


### PR DESCRIPTION
For some projects, specifying the "main" attribute makes task runners able to automatically copy the js file of this module to its correct directory (or combine it) and prevents from throwing an error that a lot of people will not figure out quickly.